### PR TITLE
fixed issue #2 - paragraphs offset

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -70,9 +70,24 @@ function downloadThread({ as = Format.PNG } = {}) {
   const pixelRatio = window.devicePixelRatio;
   const minRatio = as === Format.PDF ? 2 : 2.5;
   window.devicePixelRatio = Math.max(pixelRatio, minRatio);
-  html2canvas(elements.thread, {
-    letterRendering: true,
-  }).then(async function (canvas) {
+  html2canvas(elements.thread, 
+    {
+      letterRendering: true,
+      onclone: function (cloneDoc) {
+        //Make small fix of position to all the text containers
+        let listOfTexts = cloneDoc.getElementsByClassName('min-h-[20px]');
+
+        for (let i = 0, leng = listOfTexts.length; i < leng; i++) {
+          let text = listOfTexts[i];
+          text.style['position'] = 'relative';
+          text.style['top'] = '-8px';
+        }
+
+        //Delete copy button from code blocks
+        cloneDoc.querySelector('button.flex').remove();
+      }
+    }
+  ).then(async function (canvas) {
     elements.restoreLocation();
     window.devicePixelRatio = pixelRatio;
     const imgData = canvas.toDataURL("image/png");

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -84,7 +84,12 @@ function downloadThread({ as = Format.PNG } = {}) {
         }
 
         //Delete copy button from code blocks
-        cloneDoc.querySelector('button.flex').remove();
+        let listOfCopyBtns = cloneDoc.querySelectorAll('button.flex');
+
+        for (let i = 0, leng = listOfCopyBtns.length; i < leng; i++) {
+          let button = listOfCopyBtns[i];
+          button.remove();
+        }
       }
     }
   ).then(async function (canvas) {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -76,20 +76,16 @@ function downloadThread({ as = Format.PNG } = {}) {
       onclone: function (cloneDoc) {
         //Make small fix of position to all the text containers
         let listOfTexts = cloneDoc.getElementsByClassName('min-h-[20px]');
-
-        for (let i = 0, leng = listOfTexts.length; i < leng; i++) {
-          let text = listOfTexts[i];
-          text.style['position'] = 'relative';
-          text.style['top'] = '-8px';
-        }
+        Array.from(listOfTexts).forEach((text) => {
+          text.style.position = 'relative';
+          text.style.top = '-8px';
+        });
 
         //Delete copy button from code blocks
         let listOfCopyBtns = cloneDoc.querySelectorAll('button.flex');
-
-        for (let i = 0, leng = listOfCopyBtns.length; i < leng; i++) {
-          let button = listOfCopyBtns[i];
-          button.remove();
-        }
+        Array.from(listOfCopyBtns).forEach(
+          (btn) => (btn.remove())
+        );
       }
     }
   ).then(async function (canvas) {


### PR DESCRIPTION
fixed issue #2 - paragraphs offset

Okay, I'm going to add the bible to explain what I have done and why.

- What have I done?

I have added the attribute `onclone `to the `html2canvas` instance, this callback triggers when the library has finished of cloning the content to the canvas. Then we can edit the content of the document without changing/affecting the actual content of the page, thanks to that I added `position: relative` to the containers that contain the text from the messages and moved it up with `top: -8px`. 
I've removed the `copy code` button that appears at the top right corner of the code blocks (you can see an example in one of the screenshots I sent you in our issue conversation) because the text was moving down too for some reason, as I can't move that text up, as the button is useless in a PNG or PDF, I have removed it from the result.

- Why have I done this to fix the issue?

This problem of having the text with a small offset above it is something common in the html2canvas library ([same issue](https://github.com/niklasvh/html2canvas/issues/2775)), as this is not our page and I can't change the content of it before rendering the PNG, I decided to do it with the callback `onclone`.

Well, If you don't like something about the fix or want to ask/suggest me something, go ahead!