### PR TITLE
Fix blinking buttons while bot is writing

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -35,6 +35,11 @@ function shouldRemoveButtons() {
 }
 
 function shouldAddButtons(actionsArea) {
+  // if it should remove the button, then it shouldn't add it back, otherwise there will be an annoying loop and blinking buttons
+  if(shouldRemoveButtons()){
+    return false;
+  }
+
   // first, check if there's a "Try Again" button and no other buttons
   const buttons = actionsArea.querySelectorAll("button");
   const hasTryAgainButton = Array.from(buttons).some((button) => {


### PR DESCRIPTION
Currently the buttons start blinking, appearing and disappearing hundreds of times while the bot is typing.

This PR fixes it.